### PR TITLE
Fix Like issue on profile section posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "socially",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^6.9.6",
         "@prisma/client": "^6.1.0",

--- a/src/app/profile/[username]/ProfilePageClient.tsx
+++ b/src/app/profile/[username]/ProfilePageClient.tsx
@@ -35,6 +35,7 @@ type User = Awaited<ReturnType<typeof getProfileByUsername>>;
 type Posts = Awaited<ReturnType<typeof getUserPosts>>;
 
 interface ProfilePageClientProps {
+  authUserId: string | null;
   user: NonNullable<User>;
   posts: Posts;
   likedPosts: Posts;
@@ -46,6 +47,7 @@ function ProfilePageClient({
   likedPosts,
   posts,
   user,
+  authUserId,
 }: ProfilePageClientProps) {
   const { user: currentUser } = useUser();
   const [showEditDialog, setShowEditDialog] = useState(false);
@@ -203,7 +205,7 @@ function ProfilePageClient({
           <TabsContent value="posts" className="mt-6">
             <div className="space-y-6">
               {posts.length > 0 ? (
-                posts.map((post) => <PostCard key={post.id} post={post} dbUserId={user.id} />)
+                posts.map((post) => <PostCard key={post.id} post={post} dbUserId={authUserId} />)
               ) : (
                 <div className="text-center py-8 text-muted-foreground">No posts yet</div>
               )}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/actions/profile.action";
 import { notFound } from "next/navigation";
 import ProfilePageClient from "./ProfilePageClient";
+import { getDbUserId } from "@/actions/user.action";
 
 export async function generateMetadata({ params }: { params: { username: string } }) {
   const user = await getProfileByUsername(params.username);
@@ -19,6 +20,7 @@ export async function generateMetadata({ params }: { params: { username: string 
 
 async function ProfilePageServer({ params }: { params: { username: string } }) {
   const user = await getProfileByUsername(params.username);
+  const authUserDbId = await getDbUserId()
 
   if (!user) notFound();
 
@@ -30,6 +32,7 @@ async function ProfilePageServer({ params }: { params: { username: string } }) {
 
   return (
     <ProfilePageClient
+      authUserId={authUserDbId}
       user={user}
       posts={posts}
       likedPosts={likedPosts}


### PR DESCRIPTION
---

### 🔧 Fix: Correct Like State on Profile Page by Passing `authUserId`

#### 🐛 Problem  
When a user visits someone else’s profile and views posts, the like state is **incorrectly shown as already liked**, even if the current user hasn't liked them.  
Clicking the like button **dislikes** the post (decreases like count), and navigating back to the home page shows the correct like state.

- This was due to the `PostCard` component not knowing which user is currently authenticated.

#### ✅ Solution  
- Fetched the current authenticated user’s ID via `getDbUserId()`
- Passed this `authUserId` as a prop to `ProfilePageClient`
- Then passed `authUserId` to each `PostCard` rendered within the profile page

This ensures that the like state is correctly determined for the **current user** across all pages.

#### 📸 Before  
> Note: Like counts incorrectly decrease when clicking "Like" because the UI thinks the post is already liked

![before1](https://github.com/user-attachments/assets/0edb4e2f-c116-4767-a576-cbf74adc40cc)  
![before2](https://github.com/user-attachments/assets/1076c236-b519-4b50-83bd-73c8d21ab692)  
![before3](https://github.com/user-attachments/assets/f26e244b-a96f-4c34-a20f-ad024b961687)  
![before4](https://github.com/user-attachments/assets/f7b59986-05a0-4e50-a3b4-06bf9f92c66e)

#### ✅ After Fix  
> Note: Like state and counts are consistent across Profile and Home pages

![after1](https://github.com/user-attachments/assets/a69394ea-790d-46cf-99f7-97ea07b90c9d)  
![after2](https://github.com/user-attachments/assets/0bd86545-1210-4955-9ba3-3086dee30485)  
![after3](https://github.com/user-attachments/assets/3d0d26e8-4373-4149-b911-aa0c229c8c52)  
![after4](https://github.com/user-attachments/assets/f982b08e-1fec-4a9d-9843-aa0f82917a2d)
